### PR TITLE
Small changes in plotting

### DIFF
--- a/plot/python/plotting.py
+++ b/plot/python/plotting.py
@@ -457,7 +457,11 @@ def draw(plot, \
                     legend_text = h.sample.texName if hasattr(h.sample, "texName") else h.sample.name
                 else:
                     continue #legend_text = "No title"   
-                legend_.AddEntry(h, legend_text)
+                if hasattr(h, "legendOption"):
+                    legend_option = h.legendOption
+                    legend_.AddEntry(h, legend_text, legend_option)
+                else:
+                    legend_.AddEntry(h, legend_text)
         legend_.Draw()
 
     for o in drawObjects:
@@ -512,6 +516,8 @@ def draw(plot, \
             h_ratio.GetYaxis().SetRangeUser( *ratio['yRange'] )
             h_ratio.GetYaxis().SetNdivisions(505)
 
+            if ratio.has_key('histModifications'):
+                for modification in ratio['histModifications']: modification(h_ratio)
             drawOption = h_ratio.drawOption if hasattr(h_ratio, "drawOption") else "hist"
             if drawOption == "e1":                          # hacking to show error bars within panel when central value is off scale
               graph = ROOT.TGraphAsymmErrors(h_ratio)       # cloning in order to get layout


### PR DESCRIPTION
One small change with larger impact:
- The number of events is now stored for nanoAOD samples. Unfortunately, this requires the deletion and re-running of existing nanoAOD sample caches (takes a couple of hours, best done over night).

Two smaller changes
- Histmodifications for ratio added.
- It's now possible define the style of the legend entries (e.g. e1 for data)